### PR TITLE
Update RTUutils.cpp

### DIFF
--- a/src/RTUutils.cpp
+++ b/src/RTUutils.cpp
@@ -209,6 +209,9 @@ void RTUutils::send(HardwareSerial& serial, unsigned long& lastMicros, uint32_t 
     serial.write(crc16 & 0xff);
     serial.write((crc16 >> 8) & 0xFF);
     serial.flush();
+    // Clear serial buffers
+    while (serial.available())
+      serial.read();
     // Toggle rtsPin, if necessary
     rts(LOW);
   }


### PR DESCRIPTION
When using an RS485 auto-direction IC, the device will receive it's own transmitted frame. By clearing the serial buffers after transmit, this wont happen. Tested today.