### PR TITLE
Add support for ESP32-C3 with only 1 UART

### DIFF
--- a/src/RTUutils.cpp
+++ b/src/RTUutils.cpp
@@ -136,10 +136,12 @@ int RTUutils::UARTinit(HardwareSerial& serial, int thresholdBytes) {
         uart_num = 1;
         uart = &UART1;
       } else {
+        #if SOC_UART_NUM > 2
         if (&serial == &Serial2) {
           uart_num = 2;
           uart = &UART2;
         }
+        #endif
       }
     }
     // Is it a defined serial?


### PR DESCRIPTION
Added preprocessor macro to ignore Serial2 if it doesn't exist.

I tried to compile this for the ESP32-C3-mini and it produced errors because Serial2 is not defined for this chip. The SOC_UART_NUM is used in HardwareSerial.cpp to initialize each UART, so adding a check here stops the code trying to check for a nonexistent serial interface.