### PR TITLE
Update build_examples.yml

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -17,8 +17,8 @@ jobs:
         pip install platformio
     - name: Add libraries
       run: |
-        platformio lib -g install AsyncTCP
-        platformio lib -g install https://github.com/maxgerhardt/Ethernet.git  # Ethernet
+        pio pkg install --global --library me-no-dev/AsyncTCP
+        pio pkg install --global --library https://github.com/maxgerhardt/Ethernet.git  # Ethernet
     - name: Build examples
       run: |
         ./scripts/build_examples.sh


### PR DESCRIPTION
use up-to-date commands to install dependencies.

`pio lib install` is deprecated.