### PR TITLE
Update RTUutils.cpp

### DIFF
--- a/src/RTUutils.cpp
+++ b/src/RTUutils.cpp
@@ -237,7 +237,7 @@ ModbusMessage RTUutils::receive(HardwareSerial& serial, uint32_t timeout, unsign
   // Index into buffer
   uint16_t bufferPtr = 0;
   // Byte read
-  int b; 
+  int b{}; 
 
   // State machine states, RTU mode
   enum STATES : uint8_t { WAIT_DATA = 0, IN_PACKET, DATA_READ, FINISHED };


### PR DESCRIPTION
fix compilation issue on latest esp32 espidf
```
.pio/libdeps/esp32-network-kit/ModbusClient/src/RTUutils.cpp: In static member function 'static ModbusMessage RTUutils::receive(HardwareSerial&, uint32_t, long unsigned int&, uint32_t, bool, bool)':
.pio/libdeps/esp32-network-kit/ModbusClient/src/RTUutils.cpp:373:40: error: 'b' may be used uninitialized in this function [-Werror=maybe-uninitialized]
           if ((b & 0x80) || ASCIIread[b] == 0xFF) {
                             ~~~~~~~~~~~^
cc1plus.exe: some warnings being treated as errors
```
