### PR TITLE
stop Async server only if it's running

### DIFF
--- a/src/ModbusServerTCPasync.cpp
+++ b/src/ModbusServerTCPasync.cpp
@@ -240,6 +240,11 @@ bool ModbusServerTCPasync::stop() {
   return true;
 }
 
+bool ModbusServerTCPasync::isRunning() {
+  if (server) return true;
+  else return false;
+}
+
 void ModbusServerTCPasync::onClientConnect(AsyncClient* client) {
   LOG_D("new client\n");
   LOCK_GUARD(lock1, cListLock);

--- a/src/ModbusServerTCPasync.cpp
+++ b/src/ModbusServerTCPasync.cpp
@@ -217,6 +217,12 @@ bool ModbusServerTCPasync::start(uint16_t port, uint8_t maxClients, uint32_t tim
 }
 
 bool ModbusServerTCPasync::stop() {
+  
+  if (!server) {
+    LOG_W("Server not running.\n");
+    return false;
+  }
+  
   // stop server to prevent new clients connecting
   server->end();
 

--- a/src/ModbusServerTCPasync.h
+++ b/src/ModbusServerTCPasync.h
@@ -71,6 +71,9 @@ class ModbusServerTCPasync : public ModbusServer {
 
   // stop: drop all connections and kill server task
   bool stop();
+ 
+  // isRunning: return true is server is running
+  bool isRunning();
 
  protected:
   inline void isInstance() { }


### PR DESCRIPTION
added a check in the stop() function to avoid crash caused by stopping a non running server.