### PR TITLE
don't flush, since on arduino this also clears the RX buffer

### DIFF
--- a/src/ModbusServerTCPtemp.h
+++ b/src/ModbusServerTCPtemp.h
@@ -336,7 +336,6 @@ void ModbusServerTCP<ST, CT>::worker(ClientData *myData) {
         // Append response
         m.append(response);
         myClient.write(m.data(), m.size());
-        myClient.flush();
         HEXDUMP_V("Response", m.data(), m.size());
         // count error responses
         if (response.getError() != SUCCESS) {


### PR DESCRIPTION
`flush()` on WiFiClient [discards any unread data](https://www.arduino.cc/reference/en/libraries/wifi/client.flush/)

https://github.com/espressif/arduino-esp32/blob/21b88659b9ded3fcc1082f23f498bc2a04cd4f1b/libraries/WiFi/src/WiFiClient.cpp#L501C1-L524C2

fixes #310