### PR TITLE
Add ANY_SERVER registration

### DIFF
--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -147,7 +147,6 @@ ModbusMessage FC41(ModbusMessage request) {
 
 // Worker function for broadcast requests
 void BroadcastWorker(ModbusMessage request) {
-  HEXDUMP_N("Broadcast caught", request.data(), request.size());
   // Count broadcasts
   broadcastCnt++;
 }
@@ -1135,8 +1134,8 @@ void setup()
   Serial1.begin(BaudRate, SERIAL_8N1, GPIO_NUM_32, GPIO_NUM_33);
   Serial2.begin(BaudRate, SERIAL_8N1, GPIO_NUM_17, GPIO_NUM_16);
 
-  Serial.printf("Serial1 at %d baud\n", Serial1.baudRate());
-  Serial.printf("Serial2 at %d baud\n", Serial2.baudRate());
+  LOG_I("Serial1 at %d baud\n", Serial1.baudRate());
+  LOG_I("Serial2 at %d baud\n", Serial2.baudRate());
 
 // CHeck if connections are made
   char chkSerial[64];
@@ -1579,6 +1578,8 @@ void setup()
       ModbusError me(e);
       LOG_N("%s failed: %d - %s\n", (const char *)bcdata, (int)me, (const char *)me);
     }
+    // Wait for the server worker task to pass timeout
+    delay(5000);
     testsExecuted++;
     // We have no worker registered yet, so the message shall be discarded
     if (broadcastCnt == 0) {
@@ -1595,7 +1596,6 @@ void setup()
 
     // Now register a worker for Broadcasts
     RTUserver.registerBroadcastWorker(BroadcastWorker);
-    delay(5000);
 
     // Send BC again
     e = RTUclient.addBroadcastMessage(bcdata, bclen);
@@ -1603,6 +1603,7 @@ void setup()
       ModbusError me(e);
       LOG_N("%s failed: %d - %s\n", (const char *)bcdata, (int)me, (const char *)me);
     }
+    delay(5000);
     testsExecuted++;
     // The BC must have been caught
     if (broadcastCnt == 1) {
@@ -1612,11 +1613,65 @@ void setup()
     }
 
     // Check worker function matching patterns
-    RTUserver.registerWorker(ANY_SERVER, USER_DEFINED_66, &SVany); // FC=66 for any server ID
+    RTUserver.registerWorker(ANY_SERVER, READ_HOLD_REGISTER, &SVany); // FC=03 for any server ID
     RTUserver.registerWorker(ANY_SERVER, ANY_FUNCTION_CODE, &SVFCany); // FC=any for any server ID
+
+    // We have an explicit worker for 01/03: FC03 must be used
+    testsExecuted++;
+    auto wrk = RTUserver.getWorker(1, READ_HOLD_REGISTER).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk && *wrk == FC03) {
+      testsPassed++;
+    } else {
+      LOG_N("worker(01/03) != FC03\n");
+    }
+
+    // same for 02/03: FC03 must be used
+    testsExecuted++;
+    wrk = RTUserver.getWorker(2, READ_HOLD_REGISTER).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk && *wrk == FC03) {
+      testsPassed++;
+    } else {
+      LOG_N("worker(02/03) != FC03\n");
+    }
+
+    // 08/03 has never been defined, but we have SVany as a generic 03 worker
+    testsExecuted++;
+    wrk = RTUserver.getWorker(8, READ_HOLD_REGISTER).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk && *wrk == SVany) {
+      testsPassed++;
+    } else {
+      LOG_N("worker(08/03) != SVany\n");
+    }
+
+    // 02/66 shall be processed by FCany
+    testsExecuted++;
+    wrk = RTUserver.getWorker(2, USER_DEFINED_66).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk && *wrk == FCany) {
+      testsPassed++;
+    } else {
+      LOG_N("worker(02/66) != FCany\n");
+    }
+
+    // Finally 54/16 is to be caught by SVFCany, the "catch-all" worker
+    testsExecuted++;
+    wrk = RTUserver.getWorker(54, WRITE_MULT_REGISTERS).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk && *wrk == SVFCany) {
+      testsPassed++;
+    } else {
+      LOG_N("worker(54/16) != SVFCany\n");
+    }
 
     // Unregister ANY/ANY worker again
     RTUserver.unregisterWorker(ANY_SERVER, ANY_FUNCTION_CODE);
+
+    // Now 54/16 has no worker any more and shall return a nullptr
+    testsExecuted++;
+    wrk = RTUserver.getWorker(54, WRITE_MULT_REGISTERS).target<ModbusMessage(*)(ModbusMessage)>();
+    if (wrk) {
+      LOG_N("worker(54/16) != nullptr\n");
+    } else {
+      testsPassed++;
+    }
 
     // Check unregistering workers
     bool didit = RTUserver.unregisterWorker(1, USER_DEFINED_48);
@@ -1663,11 +1718,12 @@ void setup()
     // Loop while doubling the baud rate each turn
     MBUlogLvl = LOG_LEVEL_VERBOSE;
     while (myBaud < 5000000) {
+      delay(1000);
       Serial1.updateBaudRate(myBaud);
       Serial2.updateBaudRate(myBaud);
       RTUclient.begin(Serial1);
       RTUserver.begin(Serial2);
-      LOG_N("testing %d baud.\n", myBaud);
+      LOG_I("testing %d baud.\n", myBaud);
       testsExecuted++;
       ModbusMessage ret = RTUclient.syncRequest(myReq, Token++);
       Error e = ret.getError();
@@ -2254,10 +2310,18 @@ void setup()
   // ******************************************************************************
   // Counter tests
   // ******************************************************************************
-  Serial.printf("RTUserver: %d messages, %d errors.\n", RTUserver.getMessageCount(), RTUserver.getErrorCount());
-  Serial.printf("RTUclient: %d messages, %d errors.\n", RTUclient.getMessageCount(), RTUclient.getErrorCount());
-  Serial.printf("MBserver: %d messages, %d errors.\n", MBserver.getMessageCount(), MBserver.getErrorCount());
-  Serial.printf("Bridge: %d messages, %d errors.\n", Bridge.getMessageCount(), Bridge.getErrorCount());
+  if (RTUserver.getMessageCount() != 125 || RTUserver.getErrorCount() != 2) {
+    LOG_N("RTUserver reporting unexpected count: %d/%d instead of 125/2\n", RTUserver.getMessageCount(), RTUserver.getErrorCount());
+  }
+  if (RTUclient.getMessageCount() != 132 || RTUclient.getErrorCount() != 7) {
+    LOG_N("RTUclient reporting unexpected count: %d/%d instead of 132/7\n", RTUclient.getMessageCount(), RTUclient.getErrorCount());
+  }
+  if (MBserver.getMessageCount() != 14 || MBserver.getErrorCount() != 5) {
+    LOG_N("MBserver reporting unexpected count: %d/%d instead of 14/5\n", MBserver.getMessageCount(), MBserver.getErrorCount());
+  }
+  if (Bridge.getMessageCount() != 6 || Bridge.getErrorCount() != 4) {
+    LOG_N("Bridge reporting unexpected count: %d/%d instead of 6/4\n", Bridge.getMessageCount(), Bridge.getErrorCount());
+  }
 
 /*
   // ******************************************************************************

--- a/src/ModbusServer.h
+++ b/src/ModbusServer.h
@@ -42,7 +42,10 @@ public:
   // Returns true if the worker was found and removed
   bool unregisterWorker(uint8_t serverID, uint8_t functionCode = 0);
 
-  // isServerFor: if any worker function is registered for the given serverID, return true
+  // isServerFor: if a worker function is registered for the given serverID, return true
+  bool isServerFor(uint8_t serverID, uint8_t functionCode);
+
+  // isServerFor: short version to look up if the server is known at all
   bool isServerFor(uint8_t serverID);
 
   // getMessageCount: read number of messages processed

--- a/src/ModbusServerRTU.cpp
+++ b/src/ModbusServerRTU.cpp
@@ -185,10 +185,12 @@ void ModbusServerRTU::serve(ModbusServerRTU *myServer) {
       }
       // Is it a broadcast?
       if (request[0] == 0) {
+        LOG_N("Broadcast!\n");
         // Yes. Do we have a listener?
         if (myServer->listener) {
           // Yes. call it
           myServer->listener(request);
+          LOG_N("Broadcast served.\n");
         }
         // else we simply ignore it
       } else {

--- a/src/ModbusServerRTU.cpp
+++ b/src/ModbusServerRTU.cpp
@@ -185,12 +185,12 @@ void ModbusServerRTU::serve(ModbusServerRTU *myServer) {
       }
       // Is it a broadcast?
       if (request[0] == 0) {
-        LOG_N("Broadcast!\n");
+        LOG_D("Broadcast!\n");
         // Yes. Do we have a listener?
         if (myServer->listener) {
           // Yes. call it
           myServer->listener(request);
-          LOG_N("Broadcast served.\n");
+          LOG_D("Broadcast served.\n");
         }
         // else we simply ignore it
       } else {

--- a/src/ModbusTypeDefs.cpp
+++ b/src/ModbusTypeDefs.cpp
@@ -50,7 +50,7 @@ FCType FCT::getType(uint8_t functionCode) {
   return table[functionCode & 0x7F];
 }
 
-// setType: change the type of a function code.
+// redefineType: change the type of a function code.
 // This is possible only for the codes undefined yet and will return
 // the effective type
 FCType FCT::redefineType(uint8_t functionCode, const FCType type) {

--- a/src/ModbusTypeDefs.h
+++ b/src/ModbusTypeDefs.h
@@ -84,6 +84,9 @@ enum Error : uint8_t {
   UNDEFINED_ERROR        = 0xFF  // otherwise uncovered communication error
 };
 
+// Readable expression for the "illegal" server ID of 0
+#define ANY_SERVER 0x00
+
 #ifndef MINIMAL
 
 // Constants for float and double re-ordering


### PR DESCRIPTION
``registerWorker()`` now will accept ``ANY_SERVER`` as a server ID. 

This is potentially dangerous, as it will catch all requests to server IDs that are not covered by explicitly defined workers! 
Explicitly registered workers for combinations of a distinct server ID and a function code (also ``ANY_FUNCTION_CODE``) will have preference to the generic worker at all times.

It may be needed for some devices in the wild, though, that are (mis)using the server ID for functional purposes.

Be warned again: using ``ANY_SERVER`` may break your server's function!

``ANY_SERVER`` still is invalid for issueing requests or attaching server IDs to a bridge.