### PR TITLE
remove the front request only when the request queue is not empty.

### DIFF
--- a/src/ModbusClientRTU.cpp
+++ b/src/ModbusClientRTU.cpp
@@ -342,8 +342,11 @@ void ModbusClientRTU::handleConnection(ModbusClientRTU *instance) {
       {
         // Safely lock the queue
         LOCK_GUARD(lockGuard, instance->qLock);
-        // Remove the front queue entry
-        instance->requests.pop();
+        
+        // Remove the front queue entry if the queue is not empty
+        if (!instance->requests.empty()) { 
+          instance->requests.pop();
+        }
       }
     } else {
       delay(1);

--- a/src/ModbusClientTCP.cpp
+++ b/src/ModbusClientTCP.cpp
@@ -345,8 +345,11 @@ void ModbusClientTCP::handleConnection(ModbusClientTCP *instance) {
       {
         // Safely lock the queue
         LOCK_GUARD(lockGuard, instance->qLock);
-        // Remove the front queue entry
-        instance->requests.pop();
+
+        // Remove the front queue entry if the queue is not empty
+        if (!instance->requests.empty()) {
+          instance->requests.pop();
+        }
         // Delete request
         delete request;
         LOG_D("Request popped from queue.\n");


### PR DESCRIPTION
Issue
When clearQueue() is called within the onError() callback, it empties the request queue. If instance->requests.pop() is subsequently called, it attempts to pop from an empty queue, leading to undefined behavior and causing the MCU to crash.

Solution
To prevent the MCU from crashing, we need to ensure that instance->requests.pop() is only called if the queue is not empty.