### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build_platformio.yml
+++ b/.github/workflows/build_platformio.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library me-no-dev/AsyncTCP
+        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP
       - name: Build PlatformIO examples
         run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --board=lolin32
         env:
@@ -63,7 +63,7 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library me-no-dev/AsyncTCP
+        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP
       - name: Build PlatformIO examples
         run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --board=lolin32
         env:

--- a/library.json
+++ b/library.json
@@ -25,15 +25,15 @@
   },
   "dependencies": [
     {
-      "owner": "me-no-dev",
+      "owner": "ESP32Async",
       "name": "AsyncTCP",
-      "version": "*",
+      "version": "^3.3.7",
       "platforms": ["espressif32"]
     },
     {
-      "owner": "me-no-dev",
+      "owner": "ESP32Async",
       "name": "ESPAsyncTCP",
-      "version": "*",
+      "version": "^2.0.0",
       "platforms": ["espressif8266"]
     },
     {


### PR DESCRIPTION
Change TCP libraries to the maintained forks of ESP32Async.

Note: although some fixes have been applied, async tcp for ESP8266 still is archived.