### PR TITLE
Use tskNO_AFFINITY instead of NULL in xTaskCreatePinnedToCore

### DIFF
--- a/src/ModbusClientRTU.cpp
+++ b/src/ModbusClientRTU.cpp
@@ -86,7 +86,7 @@ void ModbusClientRTU::doBegin(uint32_t baudRate, int coreID, uint32_t userInterv
   char taskName[18];
   snprintf(taskName, 18, "Modbus%02XRTU", instanceCounter);
   // Start task to handle the queue
-  xTaskCreatePinnedToCore((TaskFunction_t)&handleConnection, taskName, CLIENT_TASK_STACK, this, 6, &worker, coreID >= 0 ? coreID : NULL);
+  xTaskCreatePinnedToCore((TaskFunction_t)&handleConnection, taskName, CLIENT_TASK_STACK, this, 6, &worker, coreID >= 0 ? coreID : tskNO_AFFINITY);
 
   LOG_D("Client task %d started. Interval=%d\n", (uint32_t)worker, MR_interval);
 }

--- a/src/ModbusClientTCP.cpp
+++ b/src/ModbusClientTCP.cpp
@@ -86,7 +86,7 @@ void ModbusClientTCP::begin(int coreID) {
     char taskName[18];
     snprintf(taskName, 18, "Modbus%02XTCP", instanceCounter);
     // Start task to handle the queue
-    xTaskCreatePinnedToCore((TaskFunction_t)&handleConnection, taskName, CLIENT_TASK_STACK, this, 5, &worker, coreID >= 0 ? coreID : NULL);
+    xTaskCreatePinnedToCore((TaskFunction_t)&handleConnection, taskName, CLIENT_TASK_STACK, this, 5, &worker, coreID >= 0 ? coreID : tskNO_AFFINITY);
     LOG_D("TCP client worker %s started\n", taskName);
 #endif
   } else {

--- a/src/ModbusServerRTU.cpp
+++ b/src/ModbusServerRTU.cpp
@@ -94,7 +94,7 @@ void ModbusServerRTU::doBegin(uint32_t baudRate, int coreID, uint32_t userInterv
   snprintf(taskName, 18, "MBsrv%02XRTU", instanceCounter);
 
   // Start task to handle the client
-  xTaskCreatePinnedToCore((TaskFunction_t)&serve, taskName, SERVER_TASK_STACK, this, 8, &serverTask, coreID >= 0 ? coreID : NULL);
+  xTaskCreatePinnedToCore((TaskFunction_t)&serve, taskName, SERVER_TASK_STACK, this, 8, &serverTask, coreID >= 0 ? coreID : tskNO_AFFINITY);
 
   LOG_D("Server task %d started. Interval=%d\n", (uint32_t)serverTask, MSRinterval);
 }

--- a/src/ModbusServerTCPtemp.h
+++ b/src/ModbusServerTCPtemp.h
@@ -157,7 +157,7 @@ template <typename ST, typename CT>
     snprintf(taskName, 18, "MBserve%04X", port);
 
     // Start task to handle the client
-    xTaskCreatePinnedToCore((TaskFunction_t)&serve, taskName, SERVER_TASK_STACK, this, 5, &serverTask, coreID >= 0 ? coreID : NULL);
+    xTaskCreatePinnedToCore((TaskFunction_t)&serve, taskName, SERVER_TASK_STACK, this, 5, &serverTask, coreID >= 0 ? coreID : tskNO_AFFINITY);
     LOG_D("Server task %s started (%d).\n", taskName, (uint32_t)serverTask);
 
     // Wait two seconds for it to establish
@@ -204,7 +204,7 @@ bool ModbusServerTCP<ST, CT>::accept(CT& client, uint32_t timeout, int coreID) {
       snprintf(taskName, 18, "MBsrv%02Xclnt", i);
 
       // Start task to handle the client
-      xTaskCreatePinnedToCore((TaskFunction_t)&worker, taskName, SERVER_TASK_STACK, clients[i], 5, &clients[i]->task, coreID >= 0 ? coreID : NULL);
+      xTaskCreatePinnedToCore((TaskFunction_t)&worker, taskName, SERVER_TASK_STACK, clients[i], 5, &clients[i]->task, coreID >= 0 ? coreID : tskNO_AFFINITY);
       LOG_D("Started client %d task %d\n", i, (uint32_t)(clients[i]->task));
 
       return true;


### PR DESCRIPTION
According espressif documentation, if you don't want to pin a task to a core, you should use tskNO_AFFINITY .

- https://docs.espressif.com/projects/esp-idf/en/v4.3/esp32/api-reference/system/freertos.html

Looking at the logic in ModbusClientTCP::begin , I expect this is what was intended. Anyways, with tskNO_AFFINITY I get better performance fro my usecase where my esp32 acts as a master to read from a TCP device and after conversion serves this back out over RTU .