### PR TITLE
Fix out-of-bounds access in setFunctionCode()

### DIFF
--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -147,13 +147,11 @@ void    ModbusMessage::setServerID(uint8_t serverID) {
 }
 
 void    ModbusMessage::setFunctionCode(uint8_t FC) {
-  // We accept here that [0], [1] may allocate bytes!
-  if (MM_data.empty()) {
-    MM_data.reserve(3);  // At least an error message should fit
+   if (MM_data.size() < 2) {
+    MM_data.resize(2);    // Resize to at least 2 to ensure indices 0 and 1 are valid
+    MM_data[0] = 0;       // Optional:  Invalid server ID as a placeholder
   }
-  // No serverID set yet? use a 0 to initialize it to an error-generating value
-  if (MM_data.size() < 2) MM_data[0] = 0; // intentional invalid server ID!
-  MM_data[1] = FC;
+  MM_data[1] = FC;        // Safely set the function code
 }
 
 // add() variant to copy a buffer into MM_data. Returns updated size


### PR DESCRIPTION
The setFunctionCode() method incorrectly uses reserve() instead of resize() to prepare the vector MM_data for writing at indices 0 and 1.

reserve() only allocates memory but does not change the vector size, so accessing MM_data[0] or MM_data[1] causes undefined behavior when the vector is empty or too small.

This commit changes reserve() to resize() to ensure valid indices exist before writing to MM_data, preventing out-of-bounds writes and potential crashes.