### PR TITLE
Fix compilation

### DIFF
--- a/.github/workflows/build_platformio.yml
+++ b/.github/workflows/build_platformio.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP
+        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP --library ESP32Async/ESPAsyncTCP
       - name: Build PlatformIO examples
-        run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --board=lolin32
+        run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --project-option="lib_compat_mode=strict" --board=lolin32
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
 
@@ -63,9 +63,9 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP
+        run: pio pkg install --global --library https://github.com/arduino-libraries/Ethernet.git --library ESP32Async/AsyncTCP --library ESP32Async/ESPAsyncTCP
       - name: Build PlatformIO examples
-        run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --board=lolin32
+        run: pio ci --lib="." --project-option="lib_ldf_mode=deep+" --project-option="lib_compat_mode=strict" --board=lolin32
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
 

--- a/library.json
+++ b/library.json
@@ -64,6 +64,7 @@
   ],
   "build":
   {
-    "lib_ldf_Mode": "deep+"
+    "libLDFMode": "deep+",
+    "libCompatMode": "strict"
   }
 }


### PR DESCRIPTION
Fixes #429 

By default Platformio doesn't check for platform compatibility when fetching and including libraries. This PR makes Platformio check for framework **and** platform compatibility.

Docs will be updated too for people that manage dependencies manually.

(includes a small fix: used wrong key for dependency finder)