### PR TITLE
Add extended response filter support to ModbusBridge

### DIFF
--- a/src/ModbusBridgeTemp.h
+++ b/src/ModbusBridgeTemp.h
@@ -311,19 +311,11 @@ ModbusMessage ModbusBridge<SERVERCLASS>::bridgeWorker(ModbusMessage msg) {
       response.setFunctionCode(functionCode);
     }
 
-    // Extended response filter hook to be called here, this includes the read start address and count for the releated request, which allows for more complex filtering
+    // Extended response filter hook to be called here, this includes the releated request, which allows for more complex filtering
     if (servers[usableID]->responseExFilter)
     {
         LOG_D("Calling request extended filter\n");
-        uint16_t address;       // Initial address requested
-        uint16_t words;         // Number of records requested
-
-		if (msg.size() >= 6) // Minimum size for a request with address and count
-        {
-            msg.get(2, address);
-            msg.get(4, words);
-            response = servers[usableID]->responseExFilter(response, address, words);
-        }
+        response = servers[usableID]->responseExFilter(response, msg);
     }
     // Response filter hook to be called here
     else if (servers[usableID]->responseFilter) {

--- a/src/ModbusBridgeTemp.h
+++ b/src/ModbusBridgeTemp.h
@@ -48,6 +48,8 @@ public:
   // Add/remove request/response filters
   bool addRequestFilter(uint8_t aliasID, MBSworker rF);
   bool removeRequestFilter(uint8_t aliasID);
+  bool addresponseExFilter(uint8_t aliasID, MBSExResponseWorker rF);
+  bool removeresponseExFilter(uint8_t aliasID);
   bool addResponseFilter(uint8_t aliasID, MBSworker rF);
   bool removeResponseFilter(uint8_t aliasID);
 
@@ -59,8 +61,9 @@ protected:
     ServerType serverType;        // TCP_SERVER or RTU_SERVER
     IPAddress host;               // TCP: host IP address, else 0.0.0.0
     uint16_t port;                // TCP: host port number, else 0
-    MBSworker requestFilter;      // optional filter requests before forwarding them
+    MBSworker requestFilter;      // optional filter requests before forwarding them	
     MBSworker responseFilter;     // optional filter responses before forwarding them
+    MBSExResponseWorker responseExFilter; // optional extended filter requests before forwarding them
 
     // RTU constructor
     ServerData(uint8_t sid, ModbusClient *c) :
@@ -70,6 +73,7 @@ protected:
       host(IPAddress(0, 0, 0, 0)),
       port(0),
       requestFilter(nullptr),
+	  responseExFilter(nullptr),
       responseFilter(nullptr) {}
     
     // TCP constructor
@@ -80,6 +84,7 @@ protected:
       host(h),
       port(p),
       requestFilter(nullptr),
+      responseExFilter(nullptr),
       responseFilter(nullptr) {}
   };
 
@@ -184,6 +189,36 @@ bool ModbusBridge<SERVERCLASS>::addRequestFilter(uint8_t aliasID, MBSworker rF) 
 }
 
 template<typename SERVERCLASS>
+bool ModbusBridge<SERVERCLASS>::addresponseExFilter(uint8_t aliasID, MBSExResponseWorker rF) {
+    // Is there already an entry for the aliasID?
+    if (servers.find(aliasID) != servers.end()) {
+        // Yes. Chain in filter function
+        servers[aliasID]->responseExFilter = rF;
+        LOG_D("Request extended filter added for server %02X\n", aliasID);
+    }
+    else {
+        LOG_E("Server %d not attached to bridge, no request filter set!\n", aliasID);
+        return false;
+    }
+    return true;
+}
+
+template<typename SERVERCLASS>
+bool ModbusBridge<SERVERCLASS>::removeresponseExFilter(uint8_t aliasID) {
+    // Is there already an entry for the aliasID?
+    if (servers.find(aliasID) != servers.end()) {
+        // Yes. Chain in filter function
+        servers[aliasID]->responseExFilter = nullptr;
+        LOG_D("Request extended filter removed for server %02X\n", aliasID);
+    }
+    else {
+        LOG_E("Server %d not attached to bridge, no request extended filter set!\n", aliasID);
+        return false;
+    }
+    return true;
+}
+
+template<typename SERVERCLASS>
 bool ModbusBridge<SERVERCLASS>::removeRequestFilter(uint8_t aliasID) {
   // Is there already an entry for the aliasID?
   if (servers.find(aliasID) != servers.end()) {
@@ -276,11 +311,25 @@ ModbusMessage ModbusBridge<SERVERCLASS>::bridgeWorker(ModbusMessage msg) {
       response.setFunctionCode(functionCode);
     }
 
+    // Extended response filter hook to be called here, this includes the read start address and count for the releated request, which allows for more complex filtering
+    if (servers[usableID]->responseExFilter)
+    {
+        LOG_D("Calling request extended filter\n");
+        uint16_t address;       // Initial address requested
+        uint16_t words;         // Number of records requested
+
+		if (msg.size() >= 6) // Minimum size for a request with address and count
+        {
+            msg.get(2, address);
+            msg.get(4, words);
+            response = servers[usableID]->responseExFilter(response, address, words);
+        }
+    }
     // Response filter hook to be called here
-    if (servers[usableID]->responseFilter) {
+    else if (servers[usableID]->responseFilter) {
       LOG_D("Calling response filter\n");
       response = servers[usableID]->responseFilter(response);
-    }
+    }    
   } else {
     // If we get here, something has gone wrong internally. We send back an error response anyway.
     response.setError(aliasID, functionCode, INVALID_SERVER);

--- a/src/ModbusServer.h
+++ b/src/ModbusServer.h
@@ -28,6 +28,7 @@ const ModbusMessage ECHO_RESPONSE(std::vector<uint8_t>{0xFF, 0xF1});
 
 // MBSworker: function signature for worker functions to handle single serverID/functionCode combinations
 using MBSworker = std::function<ModbusMessage(ModbusMessage msg)>;
+using MBSExResponseWorker = std::function<ModbusMessage(ModbusMessage msg, uint16_t ReadStartAddr, uint16_t Count)>;
 
 class ModbusServer {
 public:

--- a/src/ModbusServer.h
+++ b/src/ModbusServer.h
@@ -28,7 +28,7 @@ const ModbusMessage ECHO_RESPONSE(std::vector<uint8_t>{0xFF, 0xF1});
 
 // MBSworker: function signature for worker functions to handle single serverID/functionCode combinations
 using MBSworker = std::function<ModbusMessage(ModbusMessage msg)>;
-using MBSExResponseWorker = std::function<ModbusMessage(ModbusMessage msg, uint16_t ReadStartAddr, uint16_t Count)>;
+using MBSExResponseWorker = std::function<ModbusMessage(ModbusMessage responseMsg, ModbusMessage requestMsg)>;
 
 class ModbusServer {
 public:


### PR DESCRIPTION
Introduced `addresponseExFilter` and `removeresponseExFilter` methods to enable adding and removing extended response filters (`MBSExResponseWorker`) for specific `aliasID`s.

Added a new type alias `MBSExResponseWorker` in `ModbusServer.h` to support more complex filtering based on read start address and count. Updated the `ServerData` structure to include a `responseExFilter` member and initialized it in constructors.

Modified the `bridgeWorker` method to invoke `responseExFilter` if set, falling back to `responseFilter` otherwise if set. Added logging and updated comments to reflect the new functionality.

These changes enhance the `ModbusBridge` class, enabling more advanced and flexible filtering mechanisms for Modbus messages after receiving the request, allowing to handle the response with the original request address and count in mind.